### PR TITLE
feat: add collapsible filter panel to alerts list

### DIFF
--- a/alerts/templates/alerts/alert_list.html
+++ b/alerts/templates/alerts/alert_list.html
@@ -19,66 +19,87 @@
         </div>
     </header>
 
-    <!-- Filter Card -->
-    <div class="chart-card filter-card mb-4">
-         <div class="chart-card-body">
-            <form method="get" class="row g-3">
-                <div class="col-lg-3 col-md-6">
-                    <label for="status" class="form-label">Status</label>
-                    <select class="form-select form-select-sm" id="status" name="status">
+    <!-- Filter Panel -->
+    <div class="bg-white border rounded-md p-4 mb-4">
+        <!-- Toggle button for collapsible filters -->
+        <button id="filter-toggle"
+                class="flex items-center text-sm font-medium text-blue-600 focus:outline-none focus:ring focus:ring-blue-300"
+                aria-expanded="false"
+                aria-controls="filter-panel">
+            <span id="toggle-label" class="mr-1">Show Filters</span>
+            <svg class="w-4 h-4 transition-transform duration-300" id="chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+            </svg>
+        </button>
+
+        <!-- Collapsible filter fields -->
+        <div id="filter-panel"
+             class="mt-4 overflow-hidden max-h-0 opacity-0 transition-[max-height,opacity] duration-500 ease-in-out"
+             hidden>
+            <form method="get" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <label class="flex flex-col">
+                    <span class="text-sm font-medium text-gray-700">Status</span>
+                    <select class="mt-1 p-2 border rounded" id="status" name="status">
                         <option value="" {% if not status %}selected{% endif %}>All</option>
                         <option value="firing" {% if status == 'firing' %}selected{% endif %}>Firing</option>
                         <option value="resolved" {% if status == 'resolved' %}selected{% endif %}>Resolved</option>
                     </select>
-                </div>
-                <div class="col-lg-3 col-md-6">
-                    <label for="severity" class="form-label">Severity</label>
-                    <select class="form-select form-select-sm" id="severity" name="severity">
+                </label>
+
+                <label class="flex flex-col">
+                    <span class="text-sm font-medium text-gray-700">Severity</span>
+                    <select class="mt-1 p-2 border rounded" id="severity" name="severity">
                         <option value="" {% if not severity %}selected{% endif %}>All</option>
                         <option value="critical" {% if severity == 'critical' %}selected{% endif %}>Critical</option>
                         <option value="warning" {% if severity == 'warning' %}selected{% endif %}>Warning</option>
                         <option value="info" {% if severity == 'info' %}selected{% endif %}>Info</option>
                     </select>
-                </div>
-                <div class="col-lg-3 col-md-6">
-                    <label for="acknowledged" class="form-label">Acknowledgement</label>
-                    <select class="form-select form-select-sm" id="acknowledged" name="acknowledged">
+                </label>
+
+                <label class="flex flex-col">
+                    <span class="text-sm font-medium text-gray-700">Acknowledgement</span>
+                    <select class="mt-1 p-2 border rounded" id="acknowledged" name="acknowledged">
                         <option value="" {% if not acknowledged %}selected{% endif %}>All</option>
                         <option value="true" {% if acknowledged == 'true' %}selected{% endif %}>Acknowledged</option>
                         <option value="false" {% if acknowledged == 'false' %}selected{% endif %}>Not Acknowledged</option>
                     </select>
-                </div>
-                 <div class="col-lg-3 col-md-6">
-                    <label for="silenced" class="form-label">Silenced</label>
-                    <select class="form-select form-select-sm" id="silenced" name="silenced">
+                </label>
+
+                <label class="flex flex-col">
+                    <span class="text-sm font-medium text-gray-700">Silenced</span>
+                    <select class="mt-1 p-2 border rounded" id="silenced" name="silenced">
                         <option value="" {% if not silenced_filter %}selected{% endif %}>Show All</option>
                         <option value="no" {% if silenced_filter == 'no' %}selected{% endif %}>Hide Silenced</option>
                         <option value="yes" {% if silenced_filter == 'yes' %}selected{% endif %}>Only Silenced</option>
                     </select>
-                 </div>
-                 <div class="col-lg-3 col-md-6"> {# Adjust column classes as needed #}
-                     <label for="source_filter" class="form-label">Source</label>
-                     <select class="form-select form-select-sm" id="source_filter" name="source">
-                         <option value="" {% if not source_filter_value %}selected{% endif %}>All Sources</option>
-                         {% for src in available_sources %}
-                             <option value="{{ src }}" {% if source_filter_value == src %}selected{% endif %}>{{ src }}</option>
-                         {% endfor %}
-                     </select>
-                 </div>
-                 <div class="col-lg-6 col-md-6">
-                      <label for="instance" class="form-label">Instance</label>
-                     <input type="text" class="form-control form-control-sm" id="instance" name="instance" value="{{ instance }}" placeholder="e.g., server1:9100">
-                </div>
-                <div class="col-lg-6 col-md-6">
-                    <label for="search" class="form-label">Search</label>
-                    <input type="text" class="form-control form-control-sm" id="search" name="search" value="{{ search }}" placeholder="Name, Fingerprint...">
-                </div>
-                <div class="col-12 d-flex justify-content-end gap-2 mt-3">
-                    <button type="submit" class="btn btn-primary btn-sm">
-                        <i class='bx bx-filter-alt me-1'></i> Apply Filters
+                </label>
+
+                <label class="flex flex-col">
+                    <span class="text-sm font-medium text-gray-700">Source</span>
+                    <select class="mt-1 p-2 border rounded" id="source_filter" name="source">
+                        <option value="" {% if not source_filter_value %}selected{% endif %}>All Sources</option>
+                        {% for src in available_sources %}
+                            <option value="{{ src }}" {% if source_filter_value == src %}selected{% endif %}>{{ src }}</option>
+                        {% endfor %}
+                    </select>
+                </label>
+
+                <label class="flex flex-col sm:col-span-2">
+                    <span class="text-sm font-medium text-gray-700">Instance</span>
+                    <input type="text" class="mt-1 p-2 border rounded" id="instance" name="instance" value="{{ instance }}" placeholder="e.g., server1:9100">
+                </label>
+
+                <label class="flex flex-col sm:col-span-2">
+                    <span class="text-sm font-medium text-gray-700">Search</span>
+                    <input type="text" class="mt-1 p-2 border rounded" id="search" name="search" value="{{ search }}" placeholder="Name, Fingerprint...">
+                </label>
+
+                <div class="sm:col-span-2 lg:col-span-3 flex justify-end gap-2 mt-2">
+                    <button type="submit" class="inline-flex items-center px-3 py-2 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none focus:ring focus:ring-blue-300">
+                        <i class='bx bx-filter-alt mr-1'></i> Apply Filters
                     </button>
-                    <a href="{% url 'alerts:alert-list' %}" class="btn btn-outline-secondary btn-sm">
-                        <i class='bx bx-x me-1'></i> Reset
+                    <a href="{% url 'alerts:alert-list' %}" class="inline-flex items-center px-3 py-2 text-sm font-medium text-blue-600 border border-blue-600 rounded hover:bg-blue-50 focus:outline-none focus:ring focus:ring-blue-300">
+                        <i class='bx bx-x mr-1'></i> Reset
                     </a>
                 </div>
             </form>
@@ -262,6 +283,54 @@
 {% endblock main_content %}
 
 {% block extra_js %}
+    <script>
+        // Collapsible filter panel logic with optional localStorage persistence
+        (function () {
+            const STORAGE_KEY = 'alertFilterPanelOpen';
+            const toggleBtn  = document.getElementById('filter-toggle');
+            const panel      = document.getElementById('filter-panel');
+            const label      = document.getElementById('toggle-label');
+            const chevron    = document.getElementById('chevron');
+
+            function openPanel() {
+                panel.hidden = false;
+                panel.style.maxHeight = panel.scrollHeight + 'px';
+                panel.classList.replace('opacity-0', 'opacity-100');
+                toggleBtn.setAttribute('aria-expanded', 'true');
+                label.textContent = 'Hide Filters';
+                chevron.classList.add('rotate-180');
+                if (window.localStorage) localStorage.setItem(STORAGE_KEY, '1');
+            }
+
+            function closePanel() {
+                panel.style.maxHeight = panel.scrollHeight + 'px';
+                requestAnimationFrame(() => {
+                    panel.style.maxHeight = '0px';
+                    panel.classList.replace('opacity-100', 'opacity-0');
+                });
+                toggleBtn.setAttribute('aria-expanded', 'false');
+                label.textContent = 'Show Filters';
+                chevron.classList.remove('rotate-180');
+                panel.addEventListener('transitionend', function handler(e) {
+                    if (e.propertyName === 'max-height') {
+                        panel.hidden = true;
+                        panel.removeEventListener('transitionend', handler);
+                    }
+                });
+                if (window.localStorage) localStorage.setItem(STORAGE_KEY, '0');
+            }
+
+            function togglePanel() {
+                (toggleBtn.getAttribute('aria-expanded') === 'true') ? closePanel() : openPanel();
+            }
+
+            toggleBtn.addEventListener('click', togglePanel);
+
+            if (window.localStorage && localStorage.getItem(STORAGE_KEY) === '1') {
+                openPanel();
+            }
+        })();
+    </script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Handle row clicks for expansion

--- a/alerts/templates/alerts/alert_list.html
+++ b/alerts/templates/alerts/alert_list.html
@@ -20,10 +20,10 @@
     </header>
 
     <!-- Filter Panel -->
-    <div class="bg-white border rounded-md p-4 mb-4">
+    <div class="bg-white border rounded-md p-4 mb-4 shadow-sm">
         <!-- Toggle button for collapsible filters -->
         <button id="filter-toggle"
-                class="flex items-center text-sm font-medium text-blue-600 focus:outline-none focus:ring focus:ring-blue-300"
+                class="inline-flex items-center text-sm font-medium text-blue-600 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-300 rounded"
                 aria-expanded="false"
                 aria-controls="filter-panel">
             <span id="toggle-label" class="mr-1">Show Filters</span>
@@ -36,65 +36,69 @@
         <div id="filter-panel"
              class="mt-4 overflow-hidden max-h-0 opacity-0 transition-[max-height,opacity] duration-500 ease-in-out"
              hidden>
-            <form method="get" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                <label class="flex flex-col">
-                    <span class="text-sm font-medium text-gray-700">Status</span>
-                    <select class="mt-1 p-2 border rounded" id="status" name="status">
-                        <option value="" {% if not status %}selected{% endif %}>All</option>
-                        <option value="firing" {% if status == 'firing' %}selected{% endif %}>Firing</option>
-                        <option value="resolved" {% if status == 'resolved' %}selected{% endif %}>Resolved</option>
-                    </select>
-                </label>
+            <form method="get" class="space-y-4">
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
+                    <label class="flex flex-col">
+                        <span class="text-sm font-medium text-gray-700">Status</span>
+                        <select class="mt-1 w-full p-2 border rounded-md" id="status" name="status">
+                            <option value="" {% if not status %}selected{% endif %}>All</option>
+                            <option value="firing" {% if status == 'firing' %}selected{% endif %}>Firing</option>
+                            <option value="resolved" {% if status == 'resolved' %}selected{% endif %}>Resolved</option>
+                        </select>
+                    </label>
 
-                <label class="flex flex-col">
-                    <span class="text-sm font-medium text-gray-700">Severity</span>
-                    <select class="mt-1 p-2 border rounded" id="severity" name="severity">
-                        <option value="" {% if not severity %}selected{% endif %}>All</option>
-                        <option value="critical" {% if severity == 'critical' %}selected{% endif %}>Critical</option>
-                        <option value="warning" {% if severity == 'warning' %}selected{% endif %}>Warning</option>
-                        <option value="info" {% if severity == 'info' %}selected{% endif %}>Info</option>
-                    </select>
-                </label>
+                    <label class="flex flex-col">
+                        <span class="text-sm font-medium text-gray-700">Severity</span>
+                        <select class="mt-1 w-full p-2 border rounded-md" id="severity" name="severity">
+                            <option value="" {% if not severity %}selected{% endif %}>All</option>
+                            <option value="critical" {% if severity == 'critical' %}selected{% endif %}>Critical</option>
+                            <option value="warning" {% if severity == 'warning' %}selected{% endif %}>Warning</option>
+                            <option value="info" {% if severity == 'info' %}selected{% endif %}>Info</option>
+                        </select>
+                    </label>
 
-                <label class="flex flex-col">
-                    <span class="text-sm font-medium text-gray-700">Acknowledgement</span>
-                    <select class="mt-1 p-2 border rounded" id="acknowledged" name="acknowledged">
-                        <option value="" {% if not acknowledged %}selected{% endif %}>All</option>
-                        <option value="true" {% if acknowledged == 'true' %}selected{% endif %}>Acknowledged</option>
-                        <option value="false" {% if acknowledged == 'false' %}selected{% endif %}>Not Acknowledged</option>
-                    </select>
-                </label>
+                    <label class="flex flex-col">
+                        <span class="text-sm font-medium text-gray-700">Acknowledgement</span>
+                        <select class="mt-1 w-full p-2 border rounded-md" id="acknowledged" name="acknowledged">
+                            <option value="" {% if not acknowledged %}selected{% endif %}>All</option>
+                            <option value="true" {% if acknowledged == 'true' %}selected{% endif %}>Acknowledged</option>
+                            <option value="false" {% if acknowledged == 'false' %}selected{% endif %}>Not Acknowledged</option>
+                        </select>
+                    </label>
 
-                <label class="flex flex-col">
-                    <span class="text-sm font-medium text-gray-700">Silenced</span>
-                    <select class="mt-1 p-2 border rounded" id="silenced" name="silenced">
-                        <option value="" {% if not silenced_filter %}selected{% endif %}>Show All</option>
-                        <option value="no" {% if silenced_filter == 'no' %}selected{% endif %}>Hide Silenced</option>
-                        <option value="yes" {% if silenced_filter == 'yes' %}selected{% endif %}>Only Silenced</option>
-                    </select>
-                </label>
+                    <label class="flex flex-col">
+                        <span class="text-sm font-medium text-gray-700">Silenced</span>
+                        <select class="mt-1 w-full p-2 border rounded-md" id="silenced" name="silenced">
+                            <option value="" {% if not silenced_filter %}selected{% endif %}>Show All</option>
+                            <option value="no" {% if silenced_filter == 'no' %}selected{% endif %}>Hide Silenced</option>
+                            <option value="yes" {% if silenced_filter == 'yes' %}selected{% endif %}>Only Silenced</option>
+                        </select>
+                    </label>
 
-                <label class="flex flex-col">
-                    <span class="text-sm font-medium text-gray-700">Source</span>
-                    <select class="mt-1 p-2 border rounded" id="source_filter" name="source">
-                        <option value="" {% if not source_filter_value %}selected{% endif %}>All Sources</option>
-                        {% for src in available_sources %}
-                            <option value="{{ src }}" {% if source_filter_value == src %}selected{% endif %}>{{ src }}</option>
-                        {% endfor %}
-                    </select>
-                </label>
+                    <label class="flex flex-col">
+                        <span class="text-sm font-medium text-gray-700">Source</span>
+                        <select class="mt-1 w-full p-2 border rounded-md" id="source_filter" name="source">
+                            <option value="" {% if not source_filter_value %}selected{% endif %}>All Sources</option>
+                            {% for src in available_sources %}
+                                <option value="{{ src }}" {% if source_filter_value == src %}selected{% endif %}>{{ src }}</option>
+                            {% endfor %}
+                        </select>
+                    </label>
 
-                <label class="flex flex-col sm:col-span-2">
-                    <span class="text-sm font-medium text-gray-700">Instance</span>
-                    <input type="text" class="mt-1 p-2 border rounded" id="instance" name="instance" value="{{ instance }}" placeholder="e.g., server1:9100">
-                </label>
+                    <label class="flex flex-col">
+                        <span class="text-sm font-medium text-gray-700">Instance</span>
+                        <input type="text" class="mt-1 w-full p-2 border rounded-md" id="instance" name="instance" value="{{ instance }}" placeholder="e.g., server1:9100">
+                    </label>
 
-                <label class="flex flex-col sm:col-span-2">
-                    <span class="text-sm font-medium text-gray-700">Search</span>
-                    <input type="text" class="mt-1 p-2 border rounded" id="search" name="search" value="{{ search }}" placeholder="Name, Fingerprint...">
-                </label>
+                    <label class="flex flex-col">
+                        <span class="text-sm font-medium text-gray-700">Search</span>
+                        <input type="text" class="mt-1 w-full p-2 border rounded-md" id="search" name="search" value="{{ search }}" placeholder="Name, Fingerprint...">
+                    </label>
 
-                <div class="sm:col-span-2 lg:col-span-3 flex justify-end gap-2 mt-2">
+                    <div class="hidden md:block"></div> <!-- spacer to maintain 4-column layout -->
+                </div>
+
+                <div class="flex justify-end gap-2">
                     <button type="submit" class="inline-flex items-center px-3 py-2 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none focus:ring focus:ring-blue-300">
                         <i class='bx bx-filter-alt mr-1'></i> Apply Filters
                     </button>


### PR DESCRIPTION
## Summary
- add accessible Tailwind-based collapsible filter panel to alerts list
- persist panel state and smooth toggle animation via inline JS

## Testing
- `python3 manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_688dc99a17c88320b7b224a44f8775c7