### PR TITLE
Add missing requests dependency and upgrade Django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.20
+Django==4.2.7
 djangorestframework==3.13.1
 python-dateutil==2.8.2
 django-filter==21.1
@@ -11,4 +11,5 @@ redis==4.5.4
 jira==3.1.1
 python-dotenv==0.21.1
 pika==1.3.2
-django-celery-beat
+requests==2.32.4
+django-celery-beat==2.8.1


### PR DESCRIPTION
## Summary
- include requests in project dependencies
- pin django-celery-beat version
- upgrade Django to 4.2.7

## Testing
- `python3 manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_689595fb710483209df434a08857d548