### PR TITLE
Add live Slack template checker

### DIFF
--- a/integrations/templates/integrations/slack_rule_form.html
+++ b/integrations/templates/integrations/slack_rule_form.html
@@ -88,6 +88,12 @@
                                 {{ form.message_template|add_class:"form-control form-control-monospace" }}
                                 {% if form.message_template.help_text %}<div class="form-text">{{ form.message_template.help_text|safe }}</div>{% endif %}
                                 {% for error in form.message_template.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                                <div class="d-flex justify-content-between align-items-center mt-2">
+                                    <button type="button" class="btn btn-sm btn-outline-info" id="check-firing-template-btn">
+                                        <i class='bx bx-check-shield'></i> Check Template
+                                    </button>
+                                    <div id="firing-template-result" class="small"></div>
+                                </div>
                                 <div class="small text-muted mt-2">
                                     <strong>Hints:</strong>
                                     <ul class="mb-2">
@@ -106,6 +112,12 @@
                                 {{ form.resolved_message_template|add_class:"form-control form-control-monospace" }}
                                 {% if form.resolved_message_template.help_text %}<div class="form-text">{{ form.resolved_message_template.help_text|safe }}</div>{% endif %}
                                 {% for error in form.resolved_message_template.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                                <div class="d-flex justify-content-between align-items-center mt-2">
+                                    <button type="button" class="btn btn-sm btn-outline-info" id="check-resolved-template-btn">
+                                        <i class='bx bx-check-shield'></i> Check Template
+                                    </button>
+                                    <div id="resolved-template-result" class="small"></div>
+                                </div>
                                 <div class="small text-muted mt-2">
                                     <strong>Hints:</strong>
                                     <ul class="mb-2">
@@ -163,4 +175,65 @@
 
 {% block extra_js %}
 {{ block.super }}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+    const checkUrl = "{% url 'integrations:slack-rule-check-template' %}";
+
+    function setupTemplateChecker(buttonId, textareaId, resultId) {
+        const checkButton = document.getElementById(buttonId);
+        const templateTextarea = document.getElementById(textareaId);
+        const resultDiv = document.getElementById(resultId);
+
+        if (!checkButton || !templateTextarea || !resultDiv) {
+            console.warn(`Could not find all elements for template checker: ${buttonId}, ${textareaId}, ${resultId}`);
+            return;
+        }
+
+        checkButton.addEventListener('click', function() {
+            const templateString = templateTextarea.value;
+            resultDiv.innerHTML = `<span class="spinner-border spinner-border-sm text-muted" role="status"></span> Checking...`;
+            resultDiv.className = 'small text-muted';
+
+            fetch(checkUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken
+                },
+                body: JSON.stringify({ 'template_string': templateString })
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.status === 'success') {
+                    resultDiv.innerHTML = `<i class='bx bx-check-circle text-success'></i> Valid! Preview: <pre class="d-inline bg-light p-1 rounded" style="font-size: 0.8em;">${data.rendered}</pre>`;
+                    resultDiv.className = 'small text-success';
+                } else {
+                    resultDiv.innerHTML = `<i class='bx bx-x-circle text-danger'></i> Error: ${data.error}`;
+                    resultDiv.className = 'small text-danger';
+                }
+            })
+            .catch(error => {
+                console.error('Template check failed:', error);
+                resultDiv.innerHTML = `<i class='bx bx-error-alt text-danger'></i> Request failed. See console for details.`;
+                resultDiv.className = 'small text-danger';
+            });
+        });
+    }
+
+    // Setup for the 'firing' template
+    setupTemplateChecker(
+        'check-firing-template-btn',
+        '{{ form.message_template.id_for_label }}',
+        'firing-template-result'
+    );
+
+    // Setup for the 'resolved' template
+    setupTemplateChecker(
+        'check-resolved-template-btn',
+        '{{ form.resolved_message_template.id_for_label }}',
+        'resolved-template-result'
+    );
+});
+</script>
 {% endblock %}

--- a/integrations/tests/test_slack_template_check_view.py
+++ b/integrations/tests/test_slack_template_check_view.py
@@ -1,0 +1,34 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+import json
+
+
+class SlackTemplateCheckViewTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username='tester', password='pass')
+        self.client.login(username='tester', password='pass')
+        self.url = reverse('integrations:slack-rule-check-template')
+
+    def test_valid_template_returns_rendered_preview(self):
+        resp = self.client.post(
+            self.url,
+            data=json.dumps({'template_string': 'Hello {{ alert_group.name }}'}),
+            content_type='application/json'
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['status'], 'success')
+        self.assertIn('Hello', data['rendered'])
+
+    def test_invalid_template_returns_error(self):
+        resp = self.client.post(
+            self.url,
+            data=json.dumps({'template_string': 'Hello {{ alert_group.name|invalidfilter }}'}),
+            content_type='application/json'
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['status'], 'error')
+        self.assertIn('Template Syntax Error', data['error'])

--- a/integrations/urls.py
+++ b/integrations/urls.py
@@ -8,10 +8,11 @@ from .views import (
     SlackRuleCreateView,
     SlackRuleUpdateView,
     SlackRuleDeleteView,
-    jira_admin_view,  # Add import for the new view
-    jira_rule_guide_view,  # Import the new guide view
+    jira_admin_view,
+    jira_rule_guide_view,
     slack_admin_view,
     slack_admin_guide_view,
+    check_slack_template,
 )
 
 app_name = 'integrations'
@@ -27,6 +28,7 @@ urlpatterns = [
     path('slack-rules/<int:pk>/delete/', SlackRuleDeleteView.as_view(), name='slack-rule-delete'),
     path('jira/admin/', jira_admin_view, name='jira-admin'), # Add URL for the admin view
     path('slack/admin/', slack_admin_view, name='slack-admin'),
-    path('jira-rules/guide/', jira_rule_guide_view, name='jira-rule-guide'), # Add URL for the guide page
+    path('jira-rules/guide/', jira_rule_guide_view, name='jira-rule-guide'),
     path('slack/admin/guide/', slack_admin_guide_view, name='slack-admin-guide'),
+    path('slack-rules/check-template/', check_slack_template, name='slack-rule-check-template'),
 ]


### PR DESCRIPTION
## Summary
- add endpoint to validate Slack message templates
- show "Check Template" buttons with AJAX validation on Slack rule form
- test Slack template checker API

## Testing
- `python3 manage.py test integrations.tests.test_slack_template_check_view`
- `python3 manage.py test` *(partial run, 421 tests passed)*

------
https://chatgpt.com/codex/tasks/task_b_6896f1cb71e88320851e25c8237d0c5a