### PR TITLE
Retry Slack notifications on network errors

### DIFF
--- a/integrations/services/slack_service.py
+++ b/integrations/services/slack_service.py
@@ -8,6 +8,7 @@ from integrations.exceptions import SlackNotificationError
 
 logger = logging.getLogger(__name__)
 
+
 class SlackService:
     """
     Service for sending plain-text messages to Slack via an internal proxy endpoint.
@@ -24,66 +25,88 @@ class SlackService:
         """
         if not self.endpoint:
             logger.error("SlackService: SLACK_INTERNAL_ENDPOINT is not configured.")
-            metrics_manager.inc_counter("sentryhub_component_initialization_errors_total", labels={"component": "slack"})
+            metrics_manager.inc_counter(
+                "sentryhub_component_initialization_errors_total",
+                labels={"component": "slack"},
+            )
             return False
 
         channel_fixed = self._normalize_channel(channel)
         payload = {"channel": channel_fixed, "text": message}
 
-        try:
-            resp = requests.post(self.endpoint, json=payload, timeout=10)
-            resp.raise_for_status()
+        max_retries = 3
+        for attempt in range(1, max_retries + 1):
+            try:
+                resp = requests.post(self.endpoint, json=payload, timeout=10)
+                resp.raise_for_status()
 
-            body = resp.text.strip().lower()
-            if body != "ok":
-                error_msg = (
-                    f"Slack returned unexpected response "
-                    f"(status={resp.status_code}, body={resp.text!r})"
-                )
-                logger.error(
-                    "SlackService: send failed (channel=%r): %s",
+                body = resp.text.strip().lower()
+                if body != "ok":
+                    error_msg = (
+                        f"Slack returned unexpected response "
+                        f"(status={resp.status_code}, body={resp.text!r})"
+                    )
+                    logger.error(
+                        "SlackService: send failed (channel=%r): %s",
+                        channel_fixed,
+                        error_msg,
+                        exc_info=True,
+                    )
+                    metrics_manager.inc_counter(
+                        "sentryhub_slack_notifications_total",
+                        labels={"status": "failure", "reason": "bad_response"},
+                    )
+                    return False
+
+                logger.info(
+                    "Message posted to Slack channel %r: %r",
                     channel_fixed,
-                    error_msg,
+                    message[:200] + ("…" if len(message) > 200 else ""),
+                )
+                metrics_manager.inc_counter(
+                    "sentryhub_slack_notifications_total", labels={"status": "success"}
+                )
+
+                # --- MODIFIED/FIXED LINE HERE ---
+                metrics_manager.set_gauge(
+                    "sentryhub_component_last_successful_api_call_timestamp",
+                    value=time.time(),
+                    labels={"component": "slack"},
+                )
+                # --- END OF MODIFIED LINE ---
+
+                return True
+
+            except requests.exceptions.RequestException as exc:
+                logger.warning(
+                    "SlackService: HTTP request attempt %d/%d failed (channel=%r): %s",
+                    attempt,
+                    max_retries,
+                    channel_fixed,
+                    exc,
                     exc_info=True,
                 )
-                metrics_manager.inc_counter("sentryhub_slack_notifications_total", labels={"status": "failure", "reason": "bad_response"})
+                if attempt == max_retries:
+                    metrics_manager.inc_counter(
+                        "sentryhub_slack_notifications_total",
+                        labels={"status": "failure", "reason": "network_error"},
+                    )
+                    raise SlackNotificationError(
+                        "Network error during Slack notification"
+                    ) from exc
+                time.sleep(2 ** (attempt - 1))
+            except Exception as exc:
+                logger.error(
+                    "SlackService: unexpected error when sending to Slack (channel=%r): %s",
+                    channel_fixed,
+                    exc,
+                    exc_info=True,
+                )
+                metrics_manager.inc_counter(
+                    "sentryhub_slack_notifications_total",
+                    labels={"status": "failure", "reason": "unexpected"},
+                )
                 return False
-
-            logger.info(
-                "Message posted to Slack channel %r: %r",
-                channel_fixed,
-                message[:200] + ("…" if len(message) > 200 else ""),
-            )
-            metrics_manager.inc_counter("sentryhub_slack_notifications_total", labels={"status": "success"})
-            
-            # --- MODIFIED/FIXED LINE HERE ---
-            metrics_manager.set_gauge(
-                "sentryhub_component_last_successful_api_call_timestamp", 
-                value=time.time(), 
-                labels={"component": "slack"}
-            )
-            # --- END OF MODIFIED LINE ---
-
-            return True
-
-        except requests.exceptions.RequestException as exc:
-            logger.error(
-                "SlackService: HTTP request failed (channel=%r): %s",
-                channel_fixed,
-                exc,
-                exc_info=True,
-            )
-            metrics_manager.inc_counter("sentryhub_slack_notifications_total", labels={"status": "failure", "reason": "network_error"})
-            raise SlackNotificationError("Network error during Slack notification") from exc
-        except Exception as exc:
-            logger.error(
-                "SlackService: unexpected error when sending to Slack (channel=%r): %s",
-                channel_fixed,
-                exc,
-                exc_info=True,
-            )
-            metrics_manager.inc_counter("sentryhub_slack_notifications_total", labels={"status": "failure", "reason": "unexpected"})
-            return False
 
     def _normalize_channel(self, channel: str) -> str:
         if not channel:

--- a/integrations/tests/test_slack_service.py
+++ b/integrations/tests/test_slack_service.py
@@ -11,62 +11,96 @@ class SlackServiceNormalizeChannelTests(SimpleTestCase):
 
     def test_normalize_channel_behaviour_per_implementation(self):
         # Keeps channels that already start with '#'
-        self.assertEqual(self.service._normalize_channel('#general'), '#general')
+        self.assertEqual(self.service._normalize_channel("#general"), "#general")
         # Adds '#' when no special prefix; trims whitespace
-        self.assertEqual(self.service._normalize_channel('devops'), '#devops')
-        self.assertEqual(self.service._normalize_channel('  devops  '), '#devops')
+        self.assertEqual(self.service._normalize_channel("devops"), "#devops")
+        self.assertEqual(self.service._normalize_channel("  devops  "), "#devops")
         # Leaves Slack-like IDs untouched
-        self.assertEqual(self.service._normalize_channel('C123ABC'), 'C123ABC')
-        self.assertEqual(self.service._normalize_channel('G456DEF'), 'G456DEF')
-        self.assertEqual(self.service._normalize_channel('U789HIJ'), 'U789HIJ')
-        self.assertEqual(self.service._normalize_channel('D000XYZ'), 'D000XYZ')
+        self.assertEqual(self.service._normalize_channel("C123ABC"), "C123ABC")
+        self.assertEqual(self.service._normalize_channel("G456DEF"), "G456DEF")
+        self.assertEqual(self.service._normalize_channel("U789HIJ"), "U789HIJ")
+        self.assertEqual(self.service._normalize_channel("D000XYZ"), "D000XYZ")
         # Does not strip '@' per current implementation; will prefix with '#'
-        self.assertEqual(self.service._normalize_channel('@alerts'), '#@alerts')
+        self.assertEqual(self.service._normalize_channel("@alerts"), "#@alerts")
         # Falsy input returns as-is (empty string)
-        self.assertEqual(self.service._normalize_channel(''), '')
+        self.assertEqual(self.service._normalize_channel(""), "")
         # Whitespace-only input triggers IndexError in current implementation (ch[0] access),
         # so we assert that calling it raises IndexError to reflect current behavior.
         # Whitespace-only input should now return an empty string
-        self.assertEqual(self.service._normalize_channel('   '), '')
+        self.assertEqual(self.service._normalize_channel("   "), "")
 
 
 class SlackServiceSendNotificationTests(SimpleTestCase):
-    @override_settings(SLACK_INTERNAL_ENDPOINT='http://slack')
-    @patch('integrations.services.slack_service.metrics_manager')
+    @override_settings(SLACK_INTERNAL_ENDPOINT="http://slack")
+    @patch("integrations.services.slack_service.metrics_manager")
     def test_send_notification_success(self, metrics_mock):
         service = SlackService()
-        response_mock = Mock(status_code=200, text='ok')
+        response_mock = Mock(status_code=200, text="ok")
         response_mock.raise_for_status = Mock()
-        with patch('integrations.services.slack_service.requests.post', return_value=response_mock) as post_mock:
-            result = service.send_notification('#general', 'hi')
+        with patch(
+            "integrations.services.slack_service.requests.post",
+            return_value=response_mock,
+        ) as post_mock:
+            result = service.send_notification("#general", "hi")
         self.assertTrue(result)
         post_mock.assert_called_once()
         metrics_mock.inc_counter.assert_called()
 
-    @override_settings(SLACK_INTERNAL_ENDPOINT='http://slack')
-    @patch('integrations.services.slack_service.metrics_manager')
+    @override_settings(SLACK_INTERNAL_ENDPOINT="http://slack")
+    @patch("integrations.services.slack_service.metrics_manager")
     def test_send_notification_bad_response(self, metrics_mock):
         service = SlackService()
-        response_mock = Mock(status_code=200, text='error')
+        response_mock = Mock(status_code=200, text="error")
         response_mock.raise_for_status = Mock()
-        with patch('integrations.services.slack_service.requests.post', return_value=response_mock):
-            result = service.send_notification('#general', 'hi')
+        with patch(
+            "integrations.services.slack_service.requests.post",
+            return_value=response_mock,
+        ):
+            result = service.send_notification("#general", "hi")
         self.assertFalse(result)
         metrics_mock.inc_counter.assert_called()
 
-    @override_settings(SLACK_INTERNAL_ENDPOINT='http://slack')
-    @patch('integrations.services.slack_service.metrics_manager')
+    @override_settings(SLACK_INTERNAL_ENDPOINT="http://slack")
+    @patch("integrations.services.slack_service.metrics_manager")
     def test_send_notification_network_error_raises(self, metrics_mock):
         service = SlackService()
-        with patch('integrations.services.slack_service.requests.post', side_effect=requests.exceptions.RequestException):
-            with self.assertRaises(SlackNotificationError):
-                service.send_notification('#general', 'hi')
+        with patch(
+            "integrations.services.slack_service.requests.post",
+            side_effect=requests.exceptions.RequestException,
+        ) as post_mock:
+            with patch("integrations.services.slack_service.time.sleep") as sleep_mock:
+                with self.assertRaises(SlackNotificationError):
+                    service.send_notification("#general", "hi")
+        self.assertEqual(post_mock.call_count, 3)
+        self.assertEqual(sleep_mock.call_count, 2)
         metrics_mock.inc_counter.assert_called()
 
-    @override_settings(SLACK_INTERNAL_ENDPOINT='')
-    @patch('integrations.services.slack_service.metrics_manager')
+    @override_settings(SLACK_INTERNAL_ENDPOINT="http://slack")
+    @patch("integrations.services.slack_service.metrics_manager")
+    def test_send_notification_retries_and_succeeds(self, metrics_mock):
+        service = SlackService()
+        response_mock = Mock(status_code=200, text="ok")
+        response_mock.raise_for_status = Mock()
+        side_effects = [
+            requests.exceptions.RequestException,
+            requests.exceptions.RequestException,
+            response_mock,
+        ]
+        with patch(
+            "integrations.services.slack_service.requests.post",
+            side_effect=side_effects,
+        ) as post_mock:
+            with patch("integrations.services.slack_service.time.sleep") as sleep_mock:
+                result = service.send_notification("#general", "hi")
+        self.assertTrue(result)
+        self.assertEqual(post_mock.call_count, 3)
+        self.assertEqual(sleep_mock.call_count, 2)
+        metrics_mock.inc_counter.assert_called()
+
+    @override_settings(SLACK_INTERNAL_ENDPOINT="")
+    @patch("integrations.services.slack_service.metrics_manager")
     def test_send_notification_no_endpoint(self, metrics_mock):
         service = SlackService()
-        result = service.send_notification('#general', 'hi')
+        result = service.send_notification("#general", "hi")
         self.assertFalse(result)
         metrics_mock.inc_counter.assert_called()


### PR DESCRIPTION
## Summary
- retry Slack webhook calls with exponential backoff on failures
- test SlackService retry behaviour

## Testing
- `python3 manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_68971acb109c83209ddf94c59477eff2