### PR TITLE
Add template check for SMS rules

### DIFF
--- a/integrations/templates/integrations/sms_rule_form.html
+++ b/integrations/templates/integrations/sms_rule_form.html
@@ -78,11 +78,23 @@
                                 <label for="{{ form.firing_template.id_for_label }}" class="form-label">{{ form.firing_template.label }} <span class="badge bg-danger-subtle text-danger">Firing</span></label>
                                 {{ form.firing_template|add_class:"form-control form-control-monospace" }}
                                 {% for error in form.firing_template.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                                <div class="d-flex justify-content-between align-items-center mt-2">
+                                    <button type="button" class="btn btn-sm btn-outline-info" id="check-firing-template-btn">
+                                        <i class='bx bx-check-shield'></i> Check Template
+                                    </button>
+                                    <div id="firing-template-result" class="small"></div>
+                                </div>
                             </div>
                             <div class="col-md-6 mb-3">
                                 <label for="{{ form.resolved_template.id_for_label }}" class="form-label">{{ form.resolved_template.label }} <span class="badge bg-success-subtle text-success">Resolved</span></label>
                                 {{ form.resolved_template|add_class:"form-control form-control-monospace" }}
                                 {% for error in form.resolved_template.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                                <div class="d-flex justify-content-between align-items-center mt-2">
+                                    <button type="button" class="btn btn-sm btn-outline-info" id="check-resolved-template-btn">
+                                        <i class='bx bx-check-shield'></i> Check Template
+                                    </button>
+                                    <div id="resolved-template-result" class="small"></div>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -113,4 +125,67 @@
             </form>
         </div>
     </div>
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+        const checkUrl = "{% url 'integrations:sms-rule-check-template' %}";
+
+        function setupTemplateChecker(buttonId, textareaId, resultId) {
+            const checkButton = document.getElementById(buttonId);
+            const templateTextarea = document.getElementById(textareaId);
+            const resultDiv = document.getElementById(resultId);
+
+            if (!checkButton || !templateTextarea || !resultDiv) {
+                console.warn(`Could not find all elements for template checker: ${buttonId}, ${textareaId}, ${resultId}`);
+                return;
+            }
+
+            checkButton.addEventListener('click', function() {
+                const templateString = templateTextarea.value;
+                resultDiv.innerHTML = `<span class="spinner-border spinner-border-sm text-muted" role="status"></span> Checking...`;
+                resultDiv.className = 'small text-muted';
+
+                fetch(checkUrl, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': csrfToken
+                    },
+                    body: JSON.stringify({ 'template_string': templateString })
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.status === 'success') {
+                        resultDiv.innerHTML = `<i class='bx bx-check-circle text-success'></i> Valid! Preview: <pre class="d-inline bg-light p-1 rounded" style="font-size: 0.8em;">${data.rendered}</pre>`;
+                        resultDiv.className = 'small text-success';
+                    } else {
+                        resultDiv.innerHTML = `<i class='bx bx-x-circle text-danger'></i> Error: ${data.error}`;
+                        resultDiv.className = 'small text-danger';
+                    }
+                })
+                .catch(error => {
+                    console.error('Template check failed:', error);
+                    resultDiv.innerHTML = `<i class='bx bx-error-alt text-danger'></i> Request failed. See console for details.`;
+                    resultDiv.className = 'small text-danger';
+                });
+            });
+        }
+
+        setupTemplateChecker(
+            'check-firing-template-btn',
+            '{{ form.firing_template.id_for_label }}',
+            'firing-template-result'
+        );
+
+        setupTemplateChecker(
+            'check-resolved-template-btn',
+            '{{ form.resolved_template.id_for_label }}',
+            'resolved-template-result'
+        );
+    });
+    </script>
 {% endblock %}

--- a/integrations/tests/test_sms_template_check_view.py
+++ b/integrations/tests/test_sms_template_check_view.py
@@ -1,0 +1,34 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+import json
+
+
+class SmsTemplateCheckViewTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username='tester', password='pass')
+        self.client.login(username='tester', password='pass')
+        self.url = reverse('integrations:sms-rule-check-template')
+
+    def test_valid_template_returns_rendered_preview(self):
+        resp = self.client.post(
+            self.url,
+            data=json.dumps({'template_string': 'Hello {{ alert_group.name }}'}),
+            content_type='application/json'
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['status'], 'success')
+        self.assertIn('Hello', data['rendered'])
+
+    def test_invalid_template_returns_error(self):
+        resp = self.client.post(
+            self.url,
+            data=json.dumps({'template_string': 'Hello {{ alert_group.name|invalidfilter }}'}),
+            content_type='application/json'
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['status'], 'error')
+        self.assertIn('Template Syntax Error', data['error'])

--- a/integrations/urls.py
+++ b/integrations/urls.py
@@ -21,6 +21,7 @@ from .views import (
     slack_admin_view,
     slack_admin_guide_view,
     check_slack_template,
+    check_sms_template,
     sms_admin_view,
     sms_rule_guide_view,
 )
@@ -51,4 +52,5 @@ urlpatterns = [
     path('slack/admin/guide/', slack_admin_guide_view, name='slack-admin-guide'),
     path('sms-rules/guide/', sms_rule_guide_view, name='sms-rule-guide'),
     path('slack-rules/check-template/', check_slack_template, name='slack-rule-check-template'),
+    path('sms-rules/check-template/', check_sms_template, name='sms-rule-check-template'),
 ]


### PR DESCRIPTION
## Summary
- add Check Template buttons to SMS rule form
- allow validating SMS templates via new endpoint
- test SMS template validation

## Testing
- `python3 manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_68a05e94cbf48320b7c3ef53766d2422