### PR TITLE
Log SMS message body with fingerprint

### DIFF
--- a/integrations/tasks.py
+++ b/integrations/tasks.py
@@ -448,6 +448,9 @@ def process_sms_for_alert_group(self, alert_group_id: int, rule_id: int):
         return
 
     sms_service = SmsService()
+    logger.info(
+        f"SMS Task {self.request.id} (FP: {fingerprint_for_log}): Message body: {message}"
+    )
     sms_service.send_bulk(recipients, message, fingerprint=fingerprint_for_log)
     logger.info(
         f"SMS Task {self.request.id} (FP: {fingerprint_for_log}): "


### PR DESCRIPTION
## Summary
- log SMS message content with fingerprint in task
- test logging of SMS message body and fingerprint

## Testing
- `python3 manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_68a06bc573c48320b4e3c235ce682330