### PR TITLE
feat: add RabbitMQ delivery option for Slack

### DIFF
--- a/sentryHub/settings.py
+++ b/sentryHub/settings.py
@@ -332,3 +332,15 @@ JIRA_CONFIG = {
     'test_project_key': 'SAM',
     'test_issue_type': 'Incident',
 }
+
+# Defines the delivery method for Slack notifications ('HTTP' or 'RABBITMQ')
+SLACK_DELIVERY_METHOD = os.environ.get('SLACK_DELIVERY_METHOD', 'HTTP')
+
+# Configuration for the external RabbitMQ instance used as a forwarder for Slack
+RABBITMQ_FORWARDER_CONFIG = {
+    'HOST': os.environ.get('RABBITMQ_FORWARDER_HOST', 'localhost'),
+    'PORT': int(os.environ.get('RABBITMQ_FORWARDER_PORT', 5672)),
+    'USER': os.environ.get('RABBITMQ_FORWARDER_USER', 'guest'),
+    'PASSWORD': os.environ.get('RABBITMQ_FORWARDER_PASSWORD', 'guest'),
+    'QUEUE_NAME': os.environ.get('RABBITMQ_SLACK_QUEUE', 'slack_notifications_queue'),
+}


### PR DESCRIPTION
## Summary
- add settings for selecting Slack delivery method and RabbitMQ forwarder config
- route SlackService to publish via HTTP or RabbitMQ
- test RabbitMQ queue publishing path

## Testing
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68a2b6c67f2c8320b2beabe201e4659b