### PR TITLE
Add RabbitMQ option for SMS delivery

### DIFF
--- a/integrations/tests/test_sms_service.py
+++ b/integrations/tests/test_sms_service.py
@@ -1,0 +1,59 @@
+from django.test import SimpleTestCase, override_settings
+from unittest.mock import Mock, patch
+import json
+
+from integrations.services.sms_service import SmsService
+
+
+class SmsServiceSendBulkTests(SimpleTestCase):
+    @override_settings(
+        SMS_PROVIDER_SEND_URL="http://sms",
+        SMS_PROVIDER_USERNAME="u",
+        SMS_PROVIDER_PASSWORD="p",
+        SMS_PROVIDER_DOMAIN="d",
+        SMS_PROVIDER_SENDER="s",
+    )
+    def test_send_bulk_via_http_success(self):
+        service = SmsService()
+        response_mock = Mock(status_code=200)
+        response_mock.raise_for_status = Mock()
+        response_mock.json = Mock(return_value={"messages": [{"status": 1}]})
+        with patch(
+            "integrations.services.sms_service.requests.post",
+            return_value=response_mock,
+        ) as post_mock:
+            result = service.send_bulk(["0912"], "hi")
+        self.assertEqual(result, {"messages": [{"status": 1}]})
+        post_mock.assert_called_once()
+
+    @override_settings(
+        SMS_DELIVERY_METHOD="RABBITMQ",
+        RABBITMQ_SMS_FORWARDER_CONFIG={
+            "HOST": "localhost",
+            "PORT": 5672,
+            "USER": "guest",
+            "PASSWORD": "guest",
+            "QUEUE_NAME": "sms_notifications_queue",
+        },
+    )
+    @patch("integrations.services.sms_service.pika.BasicProperties")
+    @patch("integrations.services.sms_service.pika.BlockingConnection")
+    def test_send_bulk_rabbitmq_success(self, connection_mock, basic_props_mock):
+        service = SmsService()
+        channel_mock = Mock()
+        connection_instance = Mock()
+        connection_instance.channel.return_value = channel_mock
+        connection_mock.return_value = connection_instance
+        basic_props_mock.return_value = Mock()
+
+        result = service.send_bulk(["0912"], "hi")
+
+        self.assertTrue(result)
+        connection_mock.assert_called_once()
+        channel_mock.queue_declare.assert_called_once_with(queue="sms_notifications_queue", durable=True)
+        channel_mock.basic_publish.assert_called_once()
+        args, kwargs = channel_mock.basic_publish.call_args
+        self.assertEqual(kwargs["routing_key"], "sms_notifications_queue")
+        self.assertEqual(json.loads(kwargs["body"]), {"recipients": ["0912"], "text": "hi"})
+        self.assertIs(kwargs["properties"], basic_props_mock.return_value)
+        connection_instance.close.assert_called_once()

--- a/sentryHub/settings.py
+++ b/sentryHub/settings.py
@@ -315,6 +315,18 @@ SMS_PROVIDER_PASSWORD = os.environ.get("SMS_PROVIDER_PASSWORD", "")
 SMS_PROVIDER_DOMAIN = os.environ.get("SMS_PROVIDER_DOMAIN", "")
 SMS_PROVIDER_SENDER = os.environ.get("SMS_PROVIDER_SENDER", "")
 
+# Defines the delivery method for SMS notifications ('HTTP' or 'RABBITMQ')
+SMS_DELIVERY_METHOD = os.environ.get('SMS_DELIVERY_METHOD', 'HTTP')
+
+# Configuration for the external RabbitMQ instance used as a forwarder for SMS
+RABBITMQ_SMS_FORWARDER_CONFIG = {
+    'HOST': os.environ.get('RABBITMQ_FORWARDER_HOST', 'localhost'),
+    'PORT': int(os.environ.get('RABBITMQ_FORWARDER_PORT', 5672)),
+    'USER': os.environ.get('RABBITMQ_FORWARDER_USER', 'guest'),
+    'PASSWORD': os.environ.get('RABBITMQ_FORWARDER_PASSWORD', 'guest'),
+    'QUEUE_NAME': os.environ.get('RABBITMQ_SMS_QUEUE', 'sms_notifications_queue'),
+}
+
 
 JIRA_CONFIG = {
     'server_url': 'https://jira.tsetmc.com',


### PR DESCRIPTION
## Summary
- support choosing SMS delivery via HTTP or RabbitMQ
- add configuration for RabbitMQ SMS forwarding
- cover SmsService RabbitMQ behaviour with tests

## Testing
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_68a2f116fc608320819c2b7817696368