### PR TITLE
Ensure integration tasks dispatch after transaction commit

### DIFF
--- a/integrations/tests/test_slack_handler.py
+++ b/integrations/tests/test_slack_handler.py
@@ -29,7 +29,11 @@ class HandleAlertProcessedSlackTests(TestCase):
         on_commit_mock.assert_called_once()
         callback = on_commit_mock.call_args[0][0]
         callback()
-        delay_mock.assert_called_once_with(alert_group_id=self.alert_group.id, rule_id=self.rule.id)
+        delay_mock.assert_called_once_with(
+            alert_group_id=self.alert_group.id,
+            rule_id=self.rule.id,
+            alert_status='firing',
+        )
 
     @patch('integrations.handlers.transaction.on_commit')
     @patch('integrations.handlers.process_slack_for_alert_group.delay')
@@ -61,4 +65,8 @@ class HandleAlertProcessedSlackTests(TestCase):
         on_commit_mock.assert_called_once()
         callback = on_commit_mock.call_args[0][0]
         callback()
-        delay_mock.assert_called_once_with(alert_group_id=self.alert_group.id, rule_id=self.rule.id)
+        delay_mock.assert_called_once_with(
+            alert_group_id=self.alert_group.id,
+            rule_id=self.rule.id,
+            alert_status='firing',
+        )

--- a/integrations/tests/test_slack_handler.py
+++ b/integrations/tests/test_slack_handler.py
@@ -20,32 +20,45 @@ class HandleAlertProcessedSlackTests(TestCase):
             match_criteria={},
         )
 
+    @patch('integrations.handlers.transaction.on_commit')
     @patch('integrations.handlers.process_slack_for_alert_group.delay')
     @patch('integrations.handlers.SlackRuleMatcherService')
-    def test_triggers_task_when_rule_matches(self, matcher_mock, delay_mock):
+    def test_triggers_task_when_rule_matches(self, matcher_mock, delay_mock, on_commit_mock):
         matcher_mock.return_value.find_matching_rule.return_value = self.rule
         alert_processed.send(sender=None, alert_group=self.alert_group, instance=None, status='firing')
+        on_commit_mock.assert_called_once()
+        callback = on_commit_mock.call_args[0][0]
+        callback()
         delay_mock.assert_called_once_with(alert_group_id=self.alert_group.id, rule_id=self.rule.id)
 
+    @patch('integrations.handlers.transaction.on_commit')
     @patch('integrations.handlers.process_slack_for_alert_group.delay')
-    def test_skips_when_silenced(self, delay_mock):
+    def test_skips_when_silenced(self, delay_mock, on_commit_mock):
         self.alert_group.is_silenced = True
         self.alert_group.save()
         alert_processed.send(sender=None, alert_group=self.alert_group, instance=None, status='firing')
+        on_commit_mock.assert_not_called()
         delay_mock.assert_not_called()
 
+    @patch('integrations.handlers.transaction.on_commit')
     @patch('integrations.handlers.process_slack_for_alert_group.delay')
     @patch('integrations.handlers.SlackRuleMatcherService')
-    def test_skips_for_non_firing_or_resolved(self, matcher_mock, delay_mock):
+    def test_skips_for_non_firing_or_resolved(self, matcher_mock, delay_mock, on_commit_mock):
         matcher_mock.return_value.find_matching_rule.return_value = self.rule
         alert_processed.send(sender=None, alert_group=self.alert_group, instance=None, status='pending')
+        on_commit_mock.assert_not_called()
         delay_mock.assert_not_called()
 
+    @patch('integrations.handlers.transaction.on_commit')
     @patch('integrations.handlers.process_slack_for_alert_group.delay')
     @patch('integrations.handlers.SlackRuleMatcherService')
-    def test_logs_include_fingerprint(self, matcher_mock, delay_mock):
+    def test_logs_include_fingerprint(self, matcher_mock, delay_mock, on_commit_mock):
         matcher_mock.return_value.find_matching_rule.return_value = self.rule
         with self.assertLogs('integrations.handlers', level='INFO') as cm:
             alert_processed.send(sender=None, alert_group=self.alert_group, instance=None, status='firing')
         log_output = ' '.join(cm.output)
         self.assertIn(f"(FP: {self.alert_group.fingerprint})", log_output)
+        on_commit_mock.assert_called_once()
+        callback = on_commit_mock.call_args[0][0]
+        callback()
+        delay_mock.assert_called_once_with(alert_group_id=self.alert_group.id, rule_id=self.rule.id)

--- a/integrations/tests/test_sms_handler.py
+++ b/integrations/tests/test_sms_handler.py
@@ -30,7 +30,11 @@ class HandleAlertProcessedSmsTests(TestCase):
         on_commit_mock.assert_called_once()
         callback = on_commit_mock.call_args[0][0]
         callback()
-        delay_mock.assert_called_once_with(alert_group_id=self.alert_group.id, rule_id=self.rule.id)
+        delay_mock.assert_called_once_with(
+            alert_group_id=self.alert_group.id,
+            rule_id=self.rule.id,
+            alert_status='firing',
+        )
 
     @patch('integrations.handlers.transaction.on_commit')
     @patch('integrations.handlers.process_sms_for_alert_group.delay')

--- a/integrations/tests/test_sms_handler.py
+++ b/integrations/tests/test_sms_handler.py
@@ -21,23 +21,31 @@ class HandleAlertProcessedSmsTests(TestCase):
             firing_template='hi',
         )
 
+    @patch('integrations.handlers.transaction.on_commit')
     @patch('integrations.handlers.process_sms_for_alert_group.delay')
     @patch('integrations.handlers.SmsRuleMatcherService')
-    def test_triggers_task_when_rule_matches(self, matcher_mock, delay_mock):
+    def test_triggers_task_when_rule_matches(self, matcher_mock, delay_mock, on_commit_mock):
         matcher_mock.return_value.find_matching_rule.return_value = self.rule
         alert_processed.send(sender=None, alert_group=self.alert_group, instance=None, status='firing')
+        on_commit_mock.assert_called_once()
+        callback = on_commit_mock.call_args[0][0]
+        callback()
         delay_mock.assert_called_once_with(alert_group_id=self.alert_group.id, rule_id=self.rule.id)
 
+    @patch('integrations.handlers.transaction.on_commit')
     @patch('integrations.handlers.process_sms_for_alert_group.delay')
-    def test_skips_when_silenced(self, delay_mock):
+    def test_skips_when_silenced(self, delay_mock, on_commit_mock):
         self.alert_group.is_silenced = True
         self.alert_group.save()
         alert_processed.send(sender=None, alert_group=self.alert_group, instance=None, status='firing')
+        on_commit_mock.assert_not_called()
         delay_mock.assert_not_called()
 
+    @patch('integrations.handlers.transaction.on_commit')
     @patch('integrations.handlers.process_sms_for_alert_group.delay')
     @patch('integrations.handlers.SmsRuleMatcherService')
-    def test_skips_for_non_firing_or_resolved(self, matcher_mock, delay_mock):
+    def test_skips_for_non_firing_or_resolved(self, matcher_mock, delay_mock, on_commit_mock):
         matcher_mock.return_value.find_matching_rule.return_value = self.rule
         alert_processed.send(sender=None, alert_group=self.alert_group, instance=None, status='pending')
+        on_commit_mock.assert_not_called()
         delay_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- wrap integration task dispatchers in transaction.on_commit to avoid race conditions with pending database changes
- update Jira, Slack, and SMS handler tests to assert the deferred task execution

## Testing
- python3 manage.py test integrations.tests.test_jira_handler integrations.tests.test_slack_handler integrations.tests.test_sms_handler

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185591a9dc832fb7600f99755539ab)